### PR TITLE
Fix sidebar navigation arrow

### DIFF
--- a/features/layout/sidebar-navigation/sidebar-navigation.module.scss
+++ b/features/layout/sidebar-navigation/sidebar-navigation.module.scss
@@ -139,3 +139,9 @@
     display: flex;
   }
 }
+
+.rotateIcon {
+  img {
+    transform: rotate(180deg);
+  }
+}

--- a/features/layout/sidebar-navigation/sidebar-navigation.tsx
+++ b/features/layout/sidebar-navigation/sidebar-navigation.tsx
@@ -90,7 +90,11 @@ export function SidebarNavigation() {
               iconSrc="/icons/arrow-left.svg"
               isCollapsed={isSidebarCollapsed}
               onClick={() => toggleSidebar()}
-              className={styles.collapseMenuItem}
+              // className={styles.collapseMenuItem}
+              className={classNames(
+                styles.collapseMenuItem,
+                isSidebarCollapsed && styles.rotateIcon,
+              )}
             />
           </ul>
         </nav>


### PR DESCRIPTION
Add style rule to conditionally rotate arrow on sidebar. Arrow points to the right when the menu is collapsed.